### PR TITLE
Style: Enforce double quotes strings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,14 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in annealing.gemspec
 gemspec
 
-gem 'minitest', '~> 5.0'
-gem 'rake', '~> 13.0', '>= 13.0.6'
-gem 'rubocop', '~> 1.23'
-gem 'rubocop-minitest', '~> 0.17.0'
-gem 'rubocop-performance', '~> 1.12'
-gem 'rubocop-rake', '~> 0.6.0'
+gem "minitest", "~> 5.0"
+gem "rake", "~> 13.0", ">= 13.0.6"
+gem "rubocop", "~> 1.23"
+gem "rubocop-minitest", "~> 0.17.0"
+gem "rubocop-performance", "~> 1.12"
+gem "rubocop-rake", "~> 0.6.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
-require 'rake/testtask'
-require 'rubocop/rake_task'
+require "bundler/gem_tasks"
+require "rake/testtask"
+require "rubocop/rake_task"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 RuboCop::RakeTask.new(:rubocop)
 
-desc 'Execute the end-to-end integration test script'
+desc "Execute the end-to-end integration test script"
 task :end_to_end_test do
   puts
-  puts 'Running full end-to-end test with bin/run'
+  puts "Running full end-to-end test with bin/run"
   puts `bin/run`
   puts
 end

--- a/annealing.gemspec
+++ b/annealing.gemspec
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-require_relative 'lib/annealing/version'
+require_relative "lib/annealing/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'annealing'
+  spec.name          = "annealing"
   spec.version       = Annealing::VERSION
-  spec.authors       = ['Luis Ezcurdia', 'Chris Bloom']
-  spec.email         = ['ing.ezcurdia@gmail.com', 'chrisbloom7@gmail.com']
-  spec.license       = 'MIT'
+  spec.authors       = ["Luis Ezcurdia", "Chris Bloom"]
+  spec.email         = ["ing.ezcurdia@gmail.com", "chrisbloom7@gmail.com"]
+  spec.license       = "MIT"
 
-  spec.summary       = 'Simulated Annealing algoritm'
-  spec.description   = 'Simulated Annealing algoritm implementation.'
-  spec.homepage      = 'https://github.com/3zcurdia/annealing'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.summary       = "Simulated Annealing"
+  spec.description   = "Simulated Annealing algoritm implementation."
+  spec.homepage      = "https://github.com/3zcurdia/annealing"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/3zcurdia/annealing'
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/3zcurdia/annealing"
   # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   # Specify which files should be added to the gem when it is released.
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = 'exe'
+  spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'ruby-prof', '~> 1.4', '>= 1.4.3'
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.add_development_dependency "ruby-prof", "~> 1.4", ">= 1.4.3"
+  spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/bin/console
+++ b/bin/console
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler/setup'
-require 'annealing'
+require "bundler/setup"
+require "annealing"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -11,5 +11,5 @@ require 'annealing'
 # require "pry"
 # Pry.start
 
-require 'irb'
+require "irb"
 IRB.start(__FILE__)

--- a/bin/run
+++ b/bin/run
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler/setup'
-require 'annealing'
+require "bundler/setup"
+require "annealing"
 
 Location = Struct.new(:name, :x, :y) do
   def inspect
@@ -17,11 +17,11 @@ Location = Struct.new(:name, :x, :y) do
 end
 
 locations = [
-  Location.new('Blaire Hills', 60, 200),
-  Location.new('Smallville', 180, 200),
-  Location.new('Boggs Harbor', 40, 120),
-  Location.new('Curtisville', 100, 120),
-  Location.new('Allentown', 20, 40)
+  Location.new("Blaire Hills", 60, 200),
+  Location.new("Smallville", 180, 200),
+  Location.new("Boggs Harbor", 40, 120),
+  Location.new("Curtisville", 100, 120),
+  Location.new("Allentown", 20, 40)
 ].shuffle
 
 energy_calculator = lambda do |state|

--- a/lib/annealing.rb
+++ b/lib/annealing.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'logger'
-require 'annealing/version'
-require 'annealing/configuration'
-require 'annealing/metal'
-require 'annealing/simulator'
+require "logger"
+require "annealing/version"
+require "annealing/configuration"
+require "annealing/metal"
+require "annealing/simulator"
 
 # Simulated Annealing algoritm
 # https://en.wikipedia.org/wiki/Simulated_annealing

--- a/lib/annealing/metal.rb
+++ b/lib/annealing/metal.rb
@@ -12,9 +12,9 @@ module Annealing
       @state_change = state_change ||
                       Annealing.configuration.state_change
 
-      raise(ArgumentError, 'Missing energy calculator function') unless @energy_calculator.respond_to?(:call)
+      raise(ArgumentError, "Missing energy calculator function") unless @energy_calculator.respond_to?(:call)
 
-      raise(ArgumentError, 'Missing state change function') unless @state_change.respond_to?(:call)
+      raise(ArgumentError, "Missing state change function") unless @state_change.respond_to?(:call)
     end
 
     def energy
@@ -36,7 +36,7 @@ module Annealing
     end
 
     def to_s
-      format('%<energy>.4f:%<value>s', energy: energy, value: state)
+      format("%<energy>.4f:%<value>s", energy: energy, value: state)
     end
 
     private

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -9,7 +9,7 @@ module Annealing
       @temperature = (temperature || default_temperature).to_f
       @cooling_rate = (cooling_rate || default_cooling_rate).to_f
 
-      raise(ArgumentError, 'Invalid initial temperature') if @temperature.negative?
+      raise(ArgumentError, "Invalid initial temperature") if @temperature.negative?
 
       normalize_cooling_rate
     end

--- a/lib/annealing/version.rb
+++ b/lib/annealing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Annealing
-  VERSION = '0.2.0'
+  VERSION = "0.2.0"
 end

--- a/test/annealing/configuration_test.rb
+++ b/test/annealing/configuration_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module Annealing
   class ConfigurationTest < Minitest::Test

--- a/test/annealing/metal_test.rb
+++ b/test/annealing/metal_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module Annealing
   class MetalTest < Minitest::Test
@@ -20,7 +20,7 @@ module Annealing
     def test_new_raises_error_if_energy_calculator_not_specified
       # when a global energy_calculator has not been defined
       Annealing.configuration.energy_calculator = nil
-      assert_raises(ArgumentError, 'Missing energy calculator function') do
+      assert_raises(ArgumentError, "Missing energy calculator function") do
         Annealing::Metal.new(nil)
       end
     end
@@ -28,7 +28,7 @@ module Annealing
     def test_new_raises_error_if_state_change_not_specified
       # when a global state_change function has not been defined
       Annealing.configuration.state_change = nil
-      assert_raises(ArgumentError, 'Missing state change function') do
+      assert_raises(ArgumentError, "Missing state change function") do
         Annealing::Metal.new(nil)
       end
     end

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module Annealing
   class SimulatorTest < Minitest::Test
@@ -34,7 +34,7 @@ module Annealing
     end
 
     def test_raises_an_error_if_the_temperature_is_negative
-      assert_raises(ArgumentError, 'Invalid initial temperature') do
+      assert_raises(ArgumentError, "Invalid initial temperature") do
         Annealing::Simulator.new(temperature: @temperature * -1)
       end
     end

--- a/test/annealing_test.rb
+++ b/test/annealing_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class AnnealingTest < Minitest::Test
   def test_has_a_version_number

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
-require 'annealing'
-require 'minitest/autorun'
-require 'ruby-prof'
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "annealing"
+require "minitest/autorun"
+require "ruby-prof"
 
 module Minitest
   class Test


### PR DESCRIPTION
# Why

As a matter of style, recently adopted a new default preference to force double quotes on strings because it helps me to make fewer changes when I want to add an interpolation into a string. And also is the new default when you generate a gem