### PR TITLE
Rename method and add comments to clarify use

### DIFF
--- a/lib/annealing/metal.rb
+++ b/lib/annealing/metal.rb
@@ -24,7 +24,7 @@ module Annealing
     # It relies on random probability to select the next state
     def cool!(new_temperature)
       cooled_metal = cool(new_temperature)
-      if better_than?(cooled_metal)
+      if prefer?(cooled_metal)
         cooled_metal
       else
         @temperature = new_temperature
@@ -49,10 +49,14 @@ module Annealing
       current_config_for(:state_change)
     end
 
-    def better_than?(cooled_metal)
+    # True if cooled_metal.energy is lower than current energy, otherwise let
+    # probability determine if we should accept a higher value over a lower
+    # value
+    def prefer?(cooled_metal)
+      return true if cooled_metal.energy < energy
+
       energy_delta = energy - cooled_metal.energy
-      energy_delta.positive? ||
-        (Math::E**(energy_delta / cooled_metal.temperature)) > rand
+      (Math::E**(energy_delta / cooled_metal.temperature)) > rand
     end
 
     def cool(new_temperature)

--- a/test/annealing/metal_test.rb
+++ b/test/annealing/metal_test.rb
@@ -58,7 +58,7 @@ module Annealing
       custom_state_changer.verify
     end
 
-    def test_cooled_returns_cooled_metal_when_prefer
+    def test_cooled_returns_cooled_metal_when_preferred
       metal = Annealing::Metal.new(@collection, @temperature)
       new_temperature = @temperature - 1
       cooled_metal = metal.stub(:prefer?, true) do
@@ -68,7 +68,7 @@ module Annealing
       refute_equal new_temperature, metal.temperature
     end
 
-    def test_cooled_returns_the_original_metal_when_not_prefer
+    def test_cooled_returns_the_original_metal_when_not_preferred
       metal = Annealing::Metal.new(@collection, @temperature)
       new_temperature = @temperature - 1
       cooled_metal = metal.stub(:prefer?, false) do

--- a/test/annealing/metal_test.rb
+++ b/test/annealing/metal_test.rb
@@ -58,53 +58,53 @@ module Annealing
       custom_state_changer.verify
     end
 
-    def test_cooled_returns_cooled_metal_when_better_than
+    def test_cooled_returns_cooled_metal_when_prefer
       metal = Annealing::Metal.new(@collection, @temperature)
       new_temperature = @temperature - 1
-      cooled_metal = metal.stub(:better_than?, true) do
+      cooled_metal = metal.stub(:prefer?, true) do
         metal.cool!(new_temperature)
       end
       refute_same metal, cooled_metal
       refute_equal new_temperature, metal.temperature
     end
 
-    def test_cooled_returns_the_original_metal_when_not_better_than
+    def test_cooled_returns_the_original_metal_when_not_prefer
       metal = Annealing::Metal.new(@collection, @temperature)
       new_temperature = @temperature - 1
-      cooled_metal = metal.stub(:better_than?, false) do
+      cooled_metal = metal.stub(:prefer?, false) do
         metal.cool!(new_temperature)
       end
       assert_same metal, cooled_metal
       assert_equal new_temperature, metal.temperature
     end
 
-    def test_better_than_calls_energy_calculator_on_cooled_state
+    def test_prefer_calls_energy_calculator_on_cooled_state
       cooled_energy = @current_energy
       changed_collection = @collection.shuffle
       custom_calculator = MiniTest::Mock.new
-      custom_calculator.expect(:call, @current_energy, [@collection])
       custom_calculator.expect(:call, cooled_energy, [changed_collection])
+      custom_calculator.expect(:call, @current_energy, [@collection])
 
       metal = Annealing::Metal.new(@collection, @temperature,
                                    energy_calculator: custom_calculator)
       cooled_metal = Annealing::Metal.new(changed_collection, @temperature,
                                           energy_calculator: custom_calculator)
-      metal.send(:better_than?, cooled_metal)
+      metal.send(:prefer?, cooled_metal)
       custom_calculator.verify
     end
 
-    def test_better_than_returns_true_when_positive_difference_between_energies
+    def test_prefer_returns_true_when_cooled_metal_has_lower_energy
       cooled_energy = @current_energy / 2
       metal = Annealing::Metal.new(@collection, @temperature)
       cooled_metal = Annealing::Metal.new(@collection.shuffle, @temperature)
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
-          assert metal.send(:better_than?, cooled_metal)
+          assert metal.send(:prefer?, cooled_metal)
         end
       end
     end
 
-    def test_better_than_true_when_negative_energy_delta_zero_probability
+    def test_prefer_true_when_compared_energy_higher_and_probability_zero
       cooled_energy = @current_energy * 2
       probability = 0
       metal = Annealing::Metal.new(@collection, @temperature)
@@ -112,13 +112,13 @@ module Annealing
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
           metal.stub(:rand, probability) do
-            assert metal.send(:better_than?, cooled_metal)
+            assert metal.send(:prefer?, cooled_metal)
           end
         end
       end
     end
 
-    def test_better_than_false_when_negative_energy_delta_nonzero_probability
+    def test_prefer_false_when_compared_energy_higher_and_probability_nonzero
       cooled_energy = @current_energy * 2
       probability = 1
       metal = Annealing::Metal.new(@collection, @temperature)
@@ -126,7 +126,7 @@ module Annealing
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
           metal.stub(:rand, probability) do
-            refute metal.send(:better_than?, cooled_metal)
+            refute metal.send(:prefer?, cooled_metal)
           end
         end
       end

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -138,7 +138,7 @@ module Annealing
       end
 
       Annealing::Metal.stub(:new, metal_klass) do
-        metal.stub(:better_than?, false) do # Always return self
+        metal.stub(:prefer?, false) do # Always prefer self
           final_state = @simulator.run(@collection, cool_down: cool_down)
           metal_klass.verify
           assert_in_delta(-16.0, final_state.temperature)


### PR DESCRIPTION
While reviewing the code I kept getting confused by how the method `better_than?` was being used. In my mind it was reading "Is the current state `self` better than the new state `cooled_metal`?" but then in the code we'd select `cooled_metal` when `better_than?` was true. In English, asking if thing A is "better than" thing B is the same as asking if thing A is "preferred to" thing B, but what we want to know is if thing A "prefers" thing B. Renaming the method to use a verb as opposed to an adjective now lets it read more like "Does the current state `self` prefer the new state `cooled_metal`?". (Using the word "prefer" also helps denote that we may occasionally select `cooled_metal` even if it isn't technically better since probability may determine to select a worse outcome for the sake of exploring the problem space.)

I also added some comments to clarify the intent of the function.