### PR TITLE
Config Cleanup: remove logger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,6 @@ calculator = PotentialSalesCalculator.new(8)
 Annealing.configuration.energy_calculator = calculator.method(:energy)
 ```
 
-### `logger`
-
-The default logger is a standard Ruby Logger that writes to stdout. You can specify a different `logger` if you wish.
-
-```ruby
-logger = Logger.new('logfile.log')
-logger.level = Logger::DEBUG
-Annealing.configuration.logger = logger
-```
-
 ### `state_change`
 
 As with `energy_calculator`, you must specify a `state_change` function in order to run any simulations; no default function is provided. The function can be any object that responds to `#call` and accepts a single argument: the `state` representing the current state that should be changed. It should return the changed state.

--- a/bin/run
+++ b/bin/run
@@ -39,7 +39,6 @@ state_change = lambda do |state|
   swapped
 end
 
-Annealing.configuration.logger.level = Logger::DEBUG
 simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.01)
 solution = simulator.run(locations,
                          energy_calculator: energy_calculator,

--- a/lib/annealing.rb
+++ b/lib/annealing.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "logger"
 require "annealing/version"
 require "annealing/configuration"
 require "annealing/configuration/configurator"
@@ -27,9 +26,5 @@ module Annealing
 
   def self.simulate(initial_state, config_hash = {})
     Simulator.new.run(initial_state, config_hash).state
-  end
-
-  def self.logger
-    configuration.logger
   end
 end

--- a/lib/annealing/configuration.rb
+++ b/lib/annealing/configuration.rb
@@ -6,7 +6,6 @@ module Annealing
     attr_accessor :cool_down,
                   :cooling_rate,
                   :energy_calculator,
-                  :logger,
                   :state_change,
                   :temperature,
                   :termination_condition
@@ -18,7 +17,6 @@ module Annealing
       end
       @cooling_rate = 0.0003
       @energy_calculator = nil
-      @logger = Logger.new($stdout, level: Logger::INFO)
       @state_change = nil
       @temperature  = 10_000.0
       @termination_condition = lambda do |_state, _energy, temperature|

--- a/lib/annealing/metal.rb
+++ b/lib/annealing/metal.rb
@@ -32,13 +32,6 @@ module Annealing
       end
     end
 
-    def to_s
-      format("%<temperature>.4f:%<energy>.4f:%<value>s",
-             temperature: temperature,
-             energy: energy,
-             value: state)
-    end
-
     private
 
     def energy_calculator

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -14,13 +14,11 @@ module Annealing
         validate_configuration!
         current = Metal.new(initial_state, temperature,
                             **configuration_overrides)
-        Annealing.logger.debug("Original: #{current}")
         steps = 0
         until termination_condition_met?(termination_condition, current)
           steps += 1
           current = reduce_temperature(cool_down, current, steps)
         end
-        Annealing.logger.debug("Optimized: #{current}")
         current
       end
     end
@@ -33,10 +31,6 @@ module Annealing
 
     def cooling_rate
       current_config_for(:cooling_rate).to_f
-    end
-
-    def logger
-      current_config_for(:logger)
     end
 
     def temperature

--- a/test/annealing/configuration/configurator_test.rb
+++ b/test/annealing/configuration/configurator_test.rb
@@ -21,10 +21,6 @@ class TestConfigurator
     current_config_for(:energy_calculator)
   end
 
-  def logger
-    current_config_for(:logger)
-  end
-
   def state_change
     current_config_for(:state_change)
   end
@@ -45,7 +41,6 @@ module Annealing
         @global_cool_down = :dummy_global_cool_down
         @global_cooling_rate = 1.0
         @global_energy_calculator = :dummy_global_energy_calculator
-        @global_logger = :dummy_global_logger
         @global_temperature = 10.0
         @global_state_change = :dummy_global_state_change
 
@@ -53,7 +48,6 @@ module Annealing
           cool_down: :dummy_instance_cool_down,
           cooling_rate: 10.0,
           energy_calculator: :dummy_instance_energy_calculator,
-          logger: :dummy_instance_logger,
           temperature: 100.0,
           state_change: :dummy_instance_state_change
         }
@@ -62,7 +56,6 @@ module Annealing
           cool_down: :dummy_local_cool_down,
           cooling_rate: 100.0,
           energy_calculator: :dummy_local_energy_calculator,
-          logger: :dummy_local_logger,
           temperature: 1_000.0,
           state_change: :dummy_local_state_change
         }
@@ -72,7 +65,6 @@ module Annealing
           config.cool_down = @global_cool_down
           config.cooling_rate = @global_cooling_rate
           config.energy_calculator = @global_energy_calculator
-          config.logger = @global_logger
           config.temperature = @global_temperature
           config.state_change = @global_state_change
         end
@@ -83,7 +75,6 @@ module Annealing
         assert_equal @global_cool_down, instance.cool_down
         assert_equal @global_cooling_rate, instance.cooling_rate
         assert_equal @global_energy_calculator, instance.energy_calculator
-        assert_equal @global_logger, instance.logger
         assert_equal @global_temperature, instance.temperature
         assert_equal @global_state_change, instance.state_change
       end
@@ -93,7 +84,6 @@ module Annealing
         assert_equal @instance_config[:cool_down], instance.cool_down
         assert_equal @instance_config[:cooling_rate], instance.cooling_rate
         assert_equal @instance_config[:energy_calculator], instance.energy_calculator
-        assert_equal @instance_config[:logger], instance.logger
         assert_equal @instance_config[:temperature], instance.temperature
         assert_equal @instance_config[:state_change], instance.state_change
       end
@@ -104,7 +94,6 @@ module Annealing
           assert_equal @local_config[:cool_down], instance.cool_down
           assert_equal @local_config[:cooling_rate], instance.cooling_rate
           assert_equal @local_config[:energy_calculator], instance.energy_calculator
-          assert_equal @local_config[:logger], instance.logger
           assert_equal @local_config[:temperature], instance.temperature
           assert_equal @local_config[:state_change], instance.state_change
         end
@@ -117,21 +106,19 @@ module Annealing
           assert_equal @local_config[:cool_down], instance.cool_down
           assert_equal @local_config[:cooling_rate], instance.cooling_rate
           assert_equal @local_config[:energy_calculator], instance.energy_calculator
-          assert_equal @local_config[:logger], instance.logger
           assert_equal @local_config[:temperature], instance.temperature
           assert_equal @local_config[:state_change], instance.state_change
         end
       end
 
       def test_can_mix_and_match_config_scopes
-        instance_config = @instance_config.slice(:energy_calculator, :logger)
+        instance_config = @instance_config.slice(:energy_calculator)
         local_config = @local_config.slice(:temperature, :state_change)
         instance = TestConfigurator.new(**instance_config)
         instance.with_configuration_overrides(local_config) do
           assert_equal @global_cool_down, instance.cool_down
           assert_equal @global_cooling_rate, instance.cooling_rate
           assert_equal instance_config[:energy_calculator], instance.energy_calculator
-          assert_equal instance_config[:logger], instance.logger
           assert_equal local_config[:temperature], instance.temperature
           assert_equal local_config[:state_change], instance.state_change
         end
@@ -143,7 +130,6 @@ module Annealing
         assert_equal @global_cool_down, second_instance.cool_down
         assert_equal @global_cooling_rate, second_instance.cooling_rate
         assert_equal @global_energy_calculator, second_instance.energy_calculator
-        assert_equal @global_logger, second_instance.logger
         assert_equal @global_temperature, second_instance.temperature
         assert_equal @global_state_change, second_instance.state_change
       end
@@ -155,7 +141,6 @@ module Annealing
           assert_equal @local_config[:cool_down], instance.cool_down
           assert_equal @local_config[:cooling_rate], instance.cooling_rate
           assert_equal @local_config[:energy_calculator], instance.energy_calculator
-          assert_equal @local_config[:logger], instance.logger
           assert_equal @local_config[:temperature], instance.temperature
           assert_equal @local_config[:state_change], instance.state_change
         end
@@ -164,7 +149,6 @@ module Annealing
           assert_equal @instance_config[:cool_down], instance.cool_down
           assert_equal @instance_config[:cooling_rate], instance.cooling_rate
           assert_equal @instance_config[:energy_calculator], instance.energy_calculator
-          assert_equal @instance_config[:logger], instance.logger
           assert_equal @instance_config[:temperature], instance.temperature
           assert_equal @instance_config[:state_change], instance.state_change
         end
@@ -174,11 +158,10 @@ module Annealing
         instance = TestConfigurator.new
         assert_empty instance.configuration_overrides
 
-        instance_config = @instance_config.slice(:energy_calculator, :logger)
+        instance_config = @instance_config.slice(:energy_calculator)
         instance = TestConfigurator.new(**instance_config)
         assert_equal({
-                       energy_calculator: instance_config[:energy_calculator],
-                       logger: instance_config[:logger]
+                       energy_calculator: instance_config[:energy_calculator]
                      }, instance.configuration_overrides)
 
         local_config = @local_config.slice(:temperature, :state_change)
@@ -186,7 +169,6 @@ module Annealing
         instance.with_configuration_overrides(local_config) do
           assert_equal({
                          energy_calculator: instance_config[:energy_calculator],
-                         logger: instance_config[:logger],
                          temperature: local_config[:temperature],
                          state_change: local_config[:state_change]
                        }, instance.configuration_overrides)

--- a/test/annealing/configuration_test.rb
+++ b/test/annealing/configuration_test.rb
@@ -18,12 +18,6 @@ module Annealing
       assert_in_delta 0.0003, @configuration.cooling_rate
     end
 
-    def test_sets_the_default_logger
-      logger = @configuration.logger
-      assert_instance_of Logger, logger
-      assert_equal Logger::INFO, @configuration.logger.level
-    end
-
     def test_sets_the_default_temperature
       assert_in_delta 10_000.0, @configuration.temperature
     end

--- a/test/annealing_test.rb
+++ b/test/annealing_test.rb
@@ -35,10 +35,4 @@ class AnnealingTest < Minitest::Test
     global_energy_calculator.verify
     global_state_changer.verify
   end
-
-  def test_returns_the_configuration_logger
-    logger = Logger.new($stdout)
-    Annealing.configure { |config| config.logger = logger }
-    assert_same logger, Annealing.logger
-  end
 end


### PR DESCRIPTION
I would like to cleanup how we handle configuration internally. This is the first of several proposed changes.

Removes the `logger` configuration - We only used this to print the starting and ending energy to stdout if the log level was low enough, but we should leave that up to the user to decide what and how to log. Removing it helps simplify the configuration.